### PR TITLE
Handle Baselines for the conversion with --line-as-region parameter

### DIFF
--- a/tests/test_kraken.py
+++ b/tests/test_kraken.py
@@ -105,3 +105,26 @@ def test_yaltai_single_alto_to_xml(custom_logger):
 
     assert len([line.baseline for line in page.lines.values()])
     # ToDo: Add a test to check for line being part of regions
+
+
+def test_alto_to_yolo_with_lines(custom_logger):
+    """Test line region detection in ALTO to YOLO conversion"""
+    runner = CliRunner()
+    test_files_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "test_files")
+    
+    result = runner.invoke(
+        yaltai_cli,
+        [
+            "convert", "alto-to-yolo",
+            os.path.join(test_files_dir, "page1.xml"),
+            "test_output",
+            "--line-as-region", "default"
+        ]
+    )
+    
+    assert result.exit_code == 0
+    assert os.path.exists("test_output/labels/page1.txt")
+    
+    # Verify line detection
+    page = XMLPage(os.path.join(test_files_dir, "page1.xml"))
+    assert any(line.tags.get("type") == "default" for line in page.lines.values())

--- a/yaltai/cli/yaltai.py
+++ b/yaltai/cli/yaltai.py
@@ -144,12 +144,12 @@ def alto_to_yolo(
         processed_lines: List[Dict] = []
 
         if line_as_region:  # ToDo: Adapt to new system
-            for line in parsed.lines:
-                if line.get("tags", {}).get("type") in line_as_region:
-                    line_type = line["tags"]["type"]
+            for _, line_obj in parsed.lines.items():
+                if line_obj.tags.get("type") in line_as_region:
+                    line_type = line_obj.tags["type"]
                     if line_type not in Zones:
                         Zones.append(line_type)
-                    processed_lines.append(line)
+                    processed_lines.append(line_obj)
 
         # Retrieve image
         image_file = Image.open(image_path)
@@ -171,12 +171,12 @@ def alto_to_yolo(
                 ZoneCounter[Zones[region_id]] += 1
 
         for line in processed_lines:
-            if not line.get("boundary"):
+            if not line.boundary:
                 continue
-            region_id = Zones.index(line["tags"]["type"])
+            region_id = Zones.index(line.tags["type"])
             local_file.append(
                 AltoToYoloZone(
-                    BOX=line["boundary"],
+                    BOX=line.boundary,
                     PAGE_WIDTH=width,
                     PAGE_HEIGHT=height,
                     tag=region_id


### PR DESCRIPTION
Updated line processing to handle BaselineLine objects from kraken's XMLPage parser correctly. Added test case to verify line region detection functionality.